### PR TITLE
Add extra functionality for csp to check queue for data

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -414,6 +414,13 @@ int csp_get_buf_free(uint16_t node, uint32_t timeout, uint32_t * size);
 void csp_buf_free(uint16_t node, uint32_t timeout);
 
 /**
+ * Check if the CSP conn has data available.
+ * Quicker lookup compared to csp_conn_read(con, 0);
+ * @param[in] conn connection
+ */
+int csp_has_data(csp_conn_t * conn);
+
+/**
  * Reboot subsystem.
  * If handled by the standard CSP service handler, the reboot handler set by csp_sys_set_reboot() on the subsystem, will be invoked.
  *

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -425,3 +425,7 @@ void csp_sendto_reply(const csp_packet_t * request_packet, csp_packet_t * reply_
 	}
 	csp_sendto(request_packet->id.pri, dst, request_packet->id.sport, request_packet->id.dport, opts, reply_packet);
 }
+
+int csp_has_data(csp_conn_t * conn) {
+	return csp_queue_size(conn->rx_queue);
+}


### PR DESCRIPTION
This adds the function csp_has_data.
This check if the queue has data rather than to go through the whole csp_read process which took surprisingly longer time.